### PR TITLE
padding無しを明示

### DIFF
--- a/source/stylesheets/_social.scss
+++ b/source/stylesheets/_social.scss
@@ -2,6 +2,7 @@
   ul {
     list-style-type: none;
     text-align: center;
+    padding: 0;
     margin-bottom: $base-margin;
   }
 


### PR DESCRIPTION
User-Agentのスタイルシートに`padding: 40px;`がついていました@Chrome
